### PR TITLE
[FEAT] #7 알람 생성, 알람 전체 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 HELP.md
 .gradle
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/sopt/collaboration/alarmy/alarm/controller/AlarmController.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/controller/AlarmController.java
@@ -1,0 +1,76 @@
+package sopt.collaboration.alarmy.alarm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sopt.collaboration.alarmy.alarm.dto.request.AlarmRequest;
+import sopt.collaboration.alarmy.alarm.dto.response.AlarmResponse;
+import sopt.collaboration.alarmy.alarm.service.AlarmService;
+import sopt.collaboration.alarmy.global.result.ResultCode;
+import sopt.collaboration.alarmy.global.result.ResultResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @Operation(
+            summary = "알람 생성",
+            description = """
+                사용자의 알람을 생성합니다.
+                ### 요청 예시 JSON:
+                ```json
+                {
+                  "timestamp": "16:20"
+                }
+                ```
+                userId는 Request Header로 전달해야 합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "알람 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 형식의 timestamp / 요청 헤더 값 오류"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 / 잘못된 URL"),
+            @ApiResponse(responseCode = "405", description = "지원하지 않는 HTTP 메서드"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 발생")
+    })
+    @PostMapping("/alarm")
+    public ResponseEntity<ResultResponse<List<AlarmResponse>>> createAlarm(
+            @RequestHeader("userId") long userId,
+            @RequestBody @Valid AlarmRequest request
+    ) {
+        List<AlarmResponse> response = alarmService.createAlarm(userId, request);
+        return ResponseEntity.status(ResultCode.ALARM_CREATE_SUCCESS.getStatus())
+                .body(ResultResponse.of(ResultCode.ALARM_CREATE_SUCCESS, response));
+    }
+
+    @Operation(
+            summary = "알람 전체 조회",
+            description = """
+                사용자의 모든 알람을 조회합니다.
+                userId는 Request Header로 전달해야 합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "알람 전체 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 헤더 값 오류"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 / 잘못된 URL"),
+            @ApiResponse(responseCode = "405", description = "지원하지 않는 HTTP 메서드"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 발생")
+    })
+    @GetMapping("/alarms")
+    public ResponseEntity<ResultResponse<List<AlarmResponse>>> getAllAlarms(
+            @RequestHeader("userId") long userId
+    ) {
+        List<AlarmResponse> response = alarmService.getAllAlarms(userId);
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.ALARM_FETCH_SUCCESS, response));
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/alarm/domain/Alarm.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/domain/Alarm.java
@@ -1,17 +1,23 @@
 package sopt.collaboration.alarmy.alarm.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import sopt.collaboration.alarmy.member.domain.Member;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Alarm {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDateTime timestamp;
+    private LocalTime timestamp;
 
     private boolean isActive;
 

--- a/src/main/java/sopt/collaboration/alarmy/alarm/dto/request/AlarmRequest.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/dto/request/AlarmRequest.java
@@ -1,0 +1,10 @@
+package sopt.collaboration.alarmy.alarm.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record AlarmRequest(
+
+        // 00:00부터 23:59까지의 24시간 형식 시간만 허용
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d)$", message = "잘못된 형식의 timestamp입니다.")
+        String timestamp
+) {}

--- a/src/main/java/sopt/collaboration/alarmy/alarm/dto/response/AlarmResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/dto/response/AlarmResponse.java
@@ -1,0 +1,7 @@
+package sopt.collaboration.alarmy.alarm.dto.response;
+
+public record AlarmResponse(
+        Long id,
+        String timestamp,
+        boolean isActive
+) {}

--- a/src/main/java/sopt/collaboration/alarmy/alarm/repository/AlarmRepository.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/repository/AlarmRepository.java
@@ -1,0 +1,11 @@
+package sopt.collaboration.alarmy.alarm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.collaboration.alarmy.alarm.domain.Alarm;
+import sopt.collaboration.alarmy.member.domain.Member;
+
+import java.util.List;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+    List<Alarm> findByMember(Member member);
+}

--- a/src/main/java/sopt/collaboration/alarmy/alarm/service/AlarmService.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/service/AlarmService.java
@@ -1,0 +1,60 @@
+package sopt.collaboration.alarmy.alarm.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sopt.collaboration.alarmy.alarm.domain.Alarm;
+import sopt.collaboration.alarmy.alarm.dto.request.AlarmRequest;
+import sopt.collaboration.alarmy.alarm.dto.response.AlarmResponse;
+import sopt.collaboration.alarmy.alarm.repository.AlarmRepository;
+import sopt.collaboration.alarmy.global.error.ErrorCode;
+import sopt.collaboration.alarmy.global.error.exception.BusinessException;
+import sopt.collaboration.alarmy.member.domain.Member;
+import sopt.collaboration.alarmy.member.repository.MemberRepository;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+    private final AlarmRepository alarmRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<AlarmResponse> createAlarm(long userId, AlarmRequest request) {
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+
+        LocalTime time = LocalTime.parse(request.timestamp());
+
+        Alarm alarm = Alarm.builder()
+                .timestamp(time)
+                .isActive(true) // true 로!
+                .member(member)
+                .build();
+
+        Alarm savedAlarm = alarmRepository.save(alarm);
+
+        return List.of(new AlarmResponse(savedAlarm.getId(), formatTime(savedAlarm.getTimestamp()), savedAlarm.isActive()));
+    }
+
+    @Transactional(readOnly = true)
+    public List<AlarmResponse> getAllAlarms(long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+
+        return alarmRepository.findByMember(member).stream()
+                .map(alarm -> new AlarmResponse(alarm.getId(), formatTime(alarm.getTimestamp()), alarm.isActive()))
+                .collect(Collectors.toList());
+    }
+
+    private String formatTime(LocalTime time) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+        return time.format(formatter);
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/member/repository/MemberRepository.java
+++ b/src/main/java/sopt/collaboration/alarmy/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package sopt.collaboration.alarmy.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.collaboration.alarmy.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}


### PR DESCRIPTION
## Related issue 🔗
- closes #7

## Work Description 📂
- [x] 알람 생성 api 구현
- [x] 전체 알람 조회 api 구현

## Trouble Shooting ⚽️
1️⃣ 입력값 "HH:MM" 검증 로직
timestamp 값 검증 로직을 AlarmRequest에 두었습니다. @Pattern을 이용해 00:00부터 23:59까지의 24시간 형식 시간만 허용합니다.

2️⃣ 알람 도메인 timestamp Localtime으로
시, 분만 필요하므로 Localtime으로 수정하였습니다.

3️⃣ db에서 phrase unique 삭제, 멤버id 1~10 추가
멤버-phrase의 unique 조건을 삭제하였습니다. db에 1부터 10까지의 멤버 id를 생성해두었습니다.

4️⃣ swagger 설정 추가
swagger 의존성을 추가하고 api에 swagger 설정을 추가해두었습니다.

## To Reviewers 📢
혹시 달라진 부분이 있는지, 빠뜨린 부분이 있는지 한번 봐주시면 감사하겠습니다 😊
