### PR TITLE
[FEAT] #9 날씨 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.2.1'
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/sopt/collaboration/alarmy/AlarmyApplication.java
+++ b/src/main/java/sopt/collaboration/alarmy/AlarmyApplication.java
@@ -2,8 +2,10 @@ package sopt.collaboration.alarmy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients(basePackages = "sopt.collaboration.alarmy.external.weather.client")
 public class AlarmyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/sopt/collaboration/alarmy/alarm/service/AlarmService.java
+++ b/src/main/java/sopt/collaboration/alarmy/alarm/service/AlarmService.java
@@ -9,6 +9,7 @@ import sopt.collaboration.alarmy.alarm.dto.response.AlarmResponse;
 import sopt.collaboration.alarmy.alarm.repository.AlarmRepository;
 import sopt.collaboration.alarmy.global.error.ErrorCode;
 import sopt.collaboration.alarmy.global.error.exception.BusinessException;
+import sopt.collaboration.alarmy.global.error.exception.NoSuchMemberException;
 import sopt.collaboration.alarmy.member.domain.Member;
 import sopt.collaboration.alarmy.member.repository.MemberRepository;
 
@@ -28,7 +29,7 @@ public class AlarmService {
     public List<AlarmResponse> createAlarm(long userId, AlarmRequest request) {
 
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(NoSuchMemberException::new);
 
         LocalTime time = LocalTime.parse(request.timestamp());
 
@@ -46,7 +47,7 @@ public class AlarmService {
     @Transactional(readOnly = true)
     public List<AlarmResponse> getAllAlarms(long userId) {
         Member member = memberRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(NoSuchMemberException::new);
 
         return alarmRepository.findByMember(member).stream()
                 .map(alarm -> new AlarmResponse(alarm.getId(), formatTime(alarm.getTimestamp()), alarm.isActive()))

--- a/src/main/java/sopt/collaboration/alarmy/common/healthcheck/HealthCheckController.java
+++ b/src/main/java/sopt/collaboration/alarmy/common/healthcheck/HealthCheckController.java
@@ -1,4 +1,4 @@
-package sopt.collaboration.alarmy.controller;
+package sopt.collaboration.alarmy.common.healthcheck;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/client/WeatherApiClient.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/client/WeatherApiClient.java
@@ -1,0 +1,19 @@
+package sopt.collaboration.alarmy.external.weather.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import sopt.collaboration.alarmy.external.weather.dto.response.ForecastDataResponse;
+
+@FeignClient(name = "weatherApiClient", url = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0")
+public interface WeatherApiClient {
+    @GetMapping(value = "/getVilageFcst", consumes = "application/json")
+    ForecastDataResponse getWeatherData(@RequestParam("ServiceKey") String serviceKey,
+                                        @RequestParam("pageNo") int pageNo,
+                                        @RequestParam("numOfRows") int numOfRows,
+                                        @RequestParam("dataType") String dataType,
+                                        @RequestParam("base_date") String baseDate,
+                                        @RequestParam("base_time") String baseTime,
+                                        @RequestParam("nx") int nx,
+                                        @RequestParam("ny") int ny);
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/config/ForecastProperties.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/config/ForecastProperties.java
@@ -1,0 +1,18 @@
+package sopt.collaboration.alarmy.external.weather.config;
+
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "forecast")
+@Data
+public class ForecastProperties {
+    private String serviceKey;
+    private int pageNo;
+    private int numOfRows;
+    private String dataType;
+    private int nx;
+    private int ny;
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/controller/WeatherController.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/controller/WeatherController.java
@@ -1,0 +1,19 @@
+package sopt.collaboration.alarmy.external.weather.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.collaboration.alarmy.external.weather.service.WeatherService;
+
+@RestController
+@RequiredArgsConstructor
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping("/weather")
+    public ResponseEntity<?> weatherInfo(){
+        return ResponseEntity.ok(weatherService.weather());
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/controller/WeatherController.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/controller/WeatherController.java
@@ -1,10 +1,16 @@
 package sopt.collaboration.alarmy.external.weather.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.collaboration.alarmy.external.weather.dto.response.WeatherResponse;
 import sopt.collaboration.alarmy.external.weather.service.WeatherService;
+import sopt.collaboration.alarmy.global.result.ResultCode;
+import sopt.collaboration.alarmy.global.result.ResultResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,8 +18,22 @@ public class WeatherController {
 
     private final WeatherService weatherService;
 
+    @Operation(
+            summary = "날씨 정보 조회",
+            description = """
+                하늘 상태, 기온 등 날씨 정보를 조회합니다.
+                """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "날씨 정보 조회 성공"),
+            @ApiResponse(responseCode = "422", description = "날씨 코드 파싱 실패"),
+            @ApiResponse(responseCode = "502", description = "기상청 API 조회 실패 || 날씨 정보 식별 실패"),
+            @ApiResponse(responseCode = "404", description = "잘못된 URL"),
+            @ApiResponse(responseCode = "405", description = "지원하지 않는 HTTP 메서드"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 발생")
+    })
     @GetMapping("/weather")
-    public ResponseEntity<?> weatherInfo(){
-        return ResponseEntity.ok(weatherService.weather());
+    public ResponseEntity<ResultResponse<WeatherResponse>> weatherInfo(){
+        return ResponseEntity.ok(ResultResponse.of(ResultCode.WEATHER_FETCH_SUCCESS, weatherService.weather()));
     }
 }

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
@@ -58,9 +58,8 @@ public class ForecastDataResponse {
                 .filter(item -> item.category.equals("PCP"))
                 .findFirst().orElseThrow(NoSuchElementException::new);
 
-        if(!rainCondition.fcstValue.equals("강수없음")){
-            return WeatherCode.RAINY;
-        }
+        if(!rainCondition.fcstValue.equals("강수없음")) return WeatherCode.RAINY;
+        if(sky.fcstValue.equals("4")) return WeatherCode.CLOUDY;
         return WeatherCode.fromCode(Integer.parseInt(sky.fcstValue));
 
     }

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
@@ -2,6 +2,7 @@ package sopt.collaboration.alarmy.external.weather.dto.response;
 
 import lombok.Data;
 import sopt.collaboration.alarmy.external.weather.dto.response.enums.WeatherCode;
+import sopt.collaboration.alarmy.global.error.exception.WeatherCodeParsingException;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -53,10 +54,10 @@ public class ForecastDataResponse {
         Items items = this.response.body.items;
         Item sky = items.getItem().stream()
                 .filter(item -> item.category.equals("SKY"))
-                .findFirst().orElseThrow(NoSuchElementException::new);
+                .findFirst().orElseThrow(WeatherCodeParsingException::new);
         Item rainCondition = items.getItem().stream()
                 .filter(item -> item.category.equals("PCP"))
-                .findFirst().orElseThrow(NoSuchElementException::new);
+                .findFirst().orElseThrow(WeatherCodeParsingException::new);
 
         if(!rainCondition.fcstValue.equals("강수없음")) return WeatherCode.RAINY;
         if(sky.fcstValue.equals("4")) return WeatherCode.CLOUDY;
@@ -67,7 +68,7 @@ public class ForecastDataResponse {
     public int getTemperature(){
         Item tmp = this.response.body.items.getItem().stream()
                 .filter(item -> item.category.equals("TMP"))
-                .findFirst().orElseThrow(NoSuchElementException::new);
+                .findFirst().orElseThrow(WeatherCodeParsingException::new);
         return Integer.parseInt(tmp.fcstValue);
     }
 

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/ForecastDataResponse.java
@@ -1,0 +1,76 @@
+package sopt.collaboration.alarmy.external.weather.dto.response;
+
+import lombok.Data;
+import sopt.collaboration.alarmy.external.weather.dto.response.enums.WeatherCode;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Data
+public class ForecastDataResponse {
+
+    private Response response;
+
+    @Data
+    public static class Response {
+        private Header header;
+        private Body body;
+    }
+
+    @Data
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Data
+    public static class Body {
+        private String dataType;
+        private Items items;
+        private int pageNo;
+        private int numOfRows;
+        private int totalCount;
+    }
+
+    @Data
+    public static class Items {
+        private List<Item> item;
+    }
+
+    @Data
+    public static class Item {
+        private String baseDate;
+        private String baseTime;
+        private String category;
+        private String fcstDate;
+        private String fcstTime;
+        private String fcstValue;
+        private int nx;
+        private int ny;
+    }
+
+    public WeatherCode getWeatherCode(){
+        Items items = this.response.body.items;
+        Item sky = items.getItem().stream()
+                .filter(item -> item.category.equals("SKY"))
+                .findFirst().orElseThrow(NoSuchElementException::new);
+        Item rainCondition = items.getItem().stream()
+                .filter(item -> item.category.equals("PCP"))
+                .findFirst().orElseThrow(NoSuchElementException::new);
+
+        if(!rainCondition.fcstValue.equals("강수없음")){
+            return WeatherCode.RAINY;
+        }
+        return WeatherCode.fromCode(Integer.parseInt(sky.fcstValue));
+
+    }
+
+    public int getTemperature(){
+        Item tmp = this.response.body.items.getItem().stream()
+                .filter(item -> item.category.equals("TMP"))
+                .findFirst().orElseThrow(NoSuchElementException::new);
+        return Integer.parseInt(tmp.fcstValue);
+    }
+
+
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/WeatherResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/WeatherResponse.java
@@ -1,0 +1,17 @@
+package sopt.collaboration.alarmy.external.weather.dto.response;
+
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
+
+public record WeatherResponse(String date, int temperature, int weatherCode) {
+
+    public static WeatherResponse from(ForecastDataResponse data){
+        LocalDate now = LocalDate.now();
+        int month = now.getMonthValue();
+        int day = now.getDayOfMonth();
+        String dayOfWeek = now.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN);
+        String date = String.format("%d월 %d일 %s", month, day, dayOfWeek);
+        return new WeatherResponse(date, data.getTemperature(), data.getWeatherCode().getCode());
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 public enum WeatherCode {
     CLEAR(1, "맑음"),
     RAINY(2, "비옴"),
-    MOSTLY_CLOUDY(3, "구름많음"),
-    CLOUDY(4, "흐림");
+    CLOUDY(3, "흐림");
 
     private final int code;
     private final String description;

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
@@ -1,0 +1,32 @@
+package sopt.collaboration.alarmy.external.weather.dto.response.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum WeatherCode {
+    CLEAR(1, "맑음"),
+    RAINY(2, "비옴"),
+    MOSTLY_CLOUDY(3, "구름많음"),
+    CLOUDY(4, "흐림");
+
+    private final int code;
+    private final String description;
+
+    WeatherCode(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public static WeatherCode fromCode(int code) {
+        for (WeatherCode condition : values()) {
+            if (condition.code == code) return condition;
+        }
+        // 예외 커스텀 해줘야 함
+        throw new IllegalArgumentException("Unknown sky condition code: " + code);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.code);
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/dto/response/enums/WeatherCode.java
@@ -1,6 +1,7 @@
 package sopt.collaboration.alarmy.external.weather.dto.response.enums;
 
 import lombok.Getter;
+import sopt.collaboration.alarmy.global.error.exception.UnknownWeatherCodeException;
 
 @Getter
 public enum WeatherCode {
@@ -21,7 +22,7 @@ public enum WeatherCode {
             if (condition.code == code) return condition;
         }
         // 예외 커스텀 해줘야 함
-        throw new IllegalArgumentException("Unknown sky condition code: " + code);
+        throw new UnknownWeatherCodeException();
     }
 
     @Override

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/service/WeatherService.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/service/WeatherService.java
@@ -1,0 +1,43 @@
+package sopt.collaboration.alarmy.external.weather.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import sopt.collaboration.alarmy.external.weather.client.WeatherApiClient;
+import sopt.collaboration.alarmy.external.weather.config.ForecastProperties;
+import sopt.collaboration.alarmy.external.weather.dto.response.ForecastDataResponse;
+import sopt.collaboration.alarmy.external.weather.dto.response.WeatherResponse;
+import sopt.collaboration.alarmy.external.weather.util.ForecastTimeUtil;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+    private final WeatherApiClient client;
+
+    private final ForecastProperties forecastProperties;
+
+    public WeatherResponse weather(){
+        LocalDateTime now = ForecastTimeUtil.getForecastBaseDateTime();
+        String forecastBaseDate = ForecastTimeUtil.getForecastBaseDate(now);
+        String forecastBaseTime = ForecastTimeUtil.getForecastBaseTime(now);
+
+        log.info("forecast properties={}", forecastProperties);
+        log.info("basedate={}, basetime={}", forecastBaseDate, forecastBaseTime);
+
+        ForecastDataResponse forecastData = client.getWeatherData(
+                forecastProperties.getServiceKey(),
+                forecastProperties.getPageNo(),
+                forecastProperties.getNumOfRows(),
+                forecastProperties.getDataType(),
+                forecastBaseDate,
+                forecastBaseTime,
+                forecastProperties.getNx(),
+                forecastProperties.getNy());
+
+        return WeatherResponse.from(forecastData);
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/external/weather/util/ForecastTimeUtil.java
+++ b/src/main/java/sopt/collaboration/alarmy/external/weather/util/ForecastTimeUtil.java
@@ -1,0 +1,49 @@
+package sopt.collaboration.alarmy.external.weather.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class ForecastTimeUtil {
+
+    /**
+     * 기상청 API를 사용하기 위해 현재 시각에 맞는 basedate, basetime을 얻기 위한 함수
+     * 기상청 단기 예보 발표 시각은 02시부터 3시간 간격
+     * API 사용 가능 시간은 해당 시각의 10분 부터
+     * 따라서 시스템 안정성을 위해 해당 시각의 20분부터 조회할 수 있도록 설계
+     * @return LocalDateTime baseDateTime
+     */
+    public static LocalDateTime getForecastBaseDateTime(){
+        LocalDateTime time = LocalDateTime.now();
+
+        int hour = time.getHour();
+        int minute = time.getMinute();
+
+        for(int i = 23; i >= 2; i-=3){
+            if((hour == i && minute > 20) || i < hour){
+                return LocalDateTime.of(
+                        time.getYear(),
+                        time.getMonthValue(),
+                        time.getDayOfMonth(),
+                        i,
+                        0
+                );
+            }
+        }
+
+        return LocalDateTime.of(
+                time.getYear(),
+                time.getMonthValue(),
+                time.getDayOfMonth(),
+                23,
+                0
+        ).minusDays(1);
+    }
+
+    public static String getForecastBaseTime(LocalDateTime time){
+        return String.format("%02d00", time.getHour());
+    }
+
+    public static String getForecastBaseDate(LocalDateTime time){
+        return String.format("%04d%02d%02d", time.getYear(), time.getMonthValue(), time.getDayOfMonth());
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/global/error/ErrorCode.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/ErrorCode.java
@@ -6,14 +6,26 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
+    /**
+     * 알람 관련 예외
+     */
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NOT_VALID_TIMESTAMP(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST, "잘못된 형식의 timestamp입니다."),
 
+    /**
+     * 날씨 API 관련 예외
+     */
+    WEATHER_CODE_PARSING_ERROR(HttpStatus.UNPROCESSABLE_ENTITY.value(), HttpStatus.UNPROCESSABLE_ENTITY, "날씨 코드 파싱 실패"),
+    UNKNOWN_WEATHER_CODE_ERROR(HttpStatus.BAD_GATEWAY.value(), HttpStatus.BAD_GATEWAY, "날씨 코드 식별 실패"),
+    EXTERNAL_API_CLIENT_ERROR(HttpStatus.BAD_GATEWAY.value(), HttpStatus.BAD_GATEWAY, "외부 API 호출 실패"),
+
+    /**
+     * 공통 예외
+     */
     NOT_SUPPORTED_METHOD_ERROR(HttpStatus.METHOD_NOT_ALLOWED.value(), HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
     NOT_FOUND_ERROR(HttpStatus.NOT_FOUND.value(), HttpStatus.NOT_FOUND, "지원하지 않는 URL입니다."),
     NOT_VALID_HEADER(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST, "요청 헤더의 값이 잘못된 형식입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류 발생")
-    ;
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류 발생");
 
     private final boolean success;
     private final int code;

--- a/src/main/java/sopt/collaboration/alarmy/global/error/ErrorResponse.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/ErrorResponse.java
@@ -2,7 +2,6 @@ package sopt.collaboration.alarmy.global.error;
 
 import lombok.Getter;
 
-@Getter
 public record ErrorResponse(boolean success, int code, String message) {
 
     public static ErrorResponse of(ErrorCode errorCode){

--- a/src/main/java/sopt/collaboration/alarmy/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package sopt.collaboration.alarmy.global.error;
 
+import feign.FeignException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -38,6 +39,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e){
         ErrorCode errorCode = ErrorCode.NOT_VALID_HEADER;
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+
+        return new ResponseEntity<>(errorResponse, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(FeignException.class)
+    protected ResponseEntity<ErrorResponse> handleFeignException(FeignException e){
+        ErrorCode errorCode = ErrorCode.EXTERNAL_API_CLIENT_ERROR;
         ErrorResponse errorResponse = ErrorResponse.of(errorCode);
 
         return new ResponseEntity<>(errorResponse, errorCode.getStatus());

--- a/src/main/java/sopt/collaboration/alarmy/global/error/exception/NoSuchMemberException.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/exception/NoSuchMemberException.java
@@ -3,7 +3,7 @@ package sopt.collaboration.alarmy.global.error.exception;
 import sopt.collaboration.alarmy.global.error.ErrorCode;
 
 public class NoSuchMemberException extends BusinessException{
-    public NoSuchMemberException(ErrorCode errorCode) {
+    public NoSuchMemberException() {
         super(ErrorCode.NOT_FOUND_MEMBER);
     }
 }

--- a/src/main/java/sopt/collaboration/alarmy/global/error/exception/NotValidTimeStampException.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/exception/NotValidTimeStampException.java
@@ -3,7 +3,7 @@ package sopt.collaboration.alarmy.global.error.exception;
 import sopt.collaboration.alarmy.global.error.ErrorCode;
 
 public class NotValidTimeStampException extends BusinessException{
-    public NotValidTimeStampException(ErrorCode errorCode) {
+    public NotValidTimeStampException() {
         super(ErrorCode.NOT_VALID_TIMESTAMP);
     }
 }

--- a/src/main/java/sopt/collaboration/alarmy/global/error/exception/UnknownWeatherCodeException.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/exception/UnknownWeatherCodeException.java
@@ -1,0 +1,9 @@
+package sopt.collaboration.alarmy.global.error.exception;
+
+import sopt.collaboration.alarmy.global.error.ErrorCode;
+
+public class UnknownWeatherCodeException extends BusinessException{
+    public UnknownWeatherCodeException() {
+        super(ErrorCode.UNKNOWN_WEATHER_CODE_ERROR);
+    }
+}

--- a/src/main/java/sopt/collaboration/alarmy/global/error/exception/WeatherCodeParsingException.java
+++ b/src/main/java/sopt/collaboration/alarmy/global/error/exception/WeatherCodeParsingException.java
@@ -1,0 +1,9 @@
+package sopt.collaboration.alarmy.global.error.exception;
+
+import sopt.collaboration.alarmy.global.error.ErrorCode;
+
+public class WeatherCodeParsingException extends BusinessException{
+    public WeatherCodeParsingException() {
+        super(ErrorCode.WEATHER_CODE_PARSING_ERROR);
+    }
+}


### PR DESCRIPTION
## Related issue 🔗
- closes #9 

## Work Description 📂
- [x] 기상청 단기 예보 API 연동
- [x] 날씨 조회 기능 관련 예외 처리

## Trouble Shooting ⚽️
- 외부 API 호출 기능을 `FeignClient`를 통해 구현했습니다.
- 현재 시각을 기상청 API로 request를 보낼 때 한 번 변환하는 과정이 있는데, 이 기능이 EC2 환경에서 제대로 작동하는지 확인해봐야 할 것 같습니다.

## To Reviewers 📢
- 지금 날씨 코드를 1(`맑음`), 2(`비옴`), 3(`흐림`) 으로만 구분을 해서, 기상청 API가 `구름 많음`이라는 상태를 반환하면 이걸 흐림으로 처리해주고 있습니다. 이 부분에 대해서 논의가 좀 필요할 것 같습니다.
- FeignClient외에 다른 더 좋은 API 호출 방식이 있다면 추천 받고 싶습니다!
